### PR TITLE
Dropdown text wrap

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -5,7 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { ChipType, ComboboxItem, DropdownItem, InputChangeEventDetail, PdButtonColor, PdButtonSize, PdButtonType, PdColumn, PdIconLocation, PdModalConfig, PdPagingLocation, PdPlacement, PdStatus, PdTableIconConfiguration, PdTableRow, PdTableStyle, SelectedEvent, TabValue, TextFieldTypes } from "./interface";
+import { ChipType, ComboboxItem, DropdownItem, InputChangeEventDetail, PdButtonColor, PdButtonSize, PdButtonType, PdColumn, PdIconLocation, PdModalConfig, PdPagingLocation, PdPlacement, PdStatus, PdTableIconConfiguration, PdTableRow, PdTableStyle, SelectedEvent, TabValue, TextFieldTypes, TextWrap } from "./interface";
 import { DateOption, Options } from "flatpickr/dist/types/options";
 export namespace Components {
     interface PdAlert {
@@ -334,6 +334,10 @@ export namespace Components {
           * Set a preselected entry by index
          */
         "setSelectedIndex": (index: number) => Promise<void>;
+        /**
+          * Selected item text wrap on words
+         */
+        "textWrap": TextWrap;
         /**
           * Default vertical adjustment for inline forms
          */
@@ -1616,6 +1620,10 @@ declare namespace LocalJSX {
           * If `true`, the user must fill in a value before submitting a form.
          */
         "required"?: boolean;
+        /**
+          * Selected item text wrap on words
+         */
+        "textWrap"?: TextWrap;
         /**
           * Default vertical adjustment for inline forms
          */

--- a/src/components/pd-dropdown/pd-dropdown.scss
+++ b/src/components/pd-dropdown/pd-dropdown.scss
@@ -44,7 +44,12 @@
             text-align: left;
             text-overflow: ellipsis;
             overflow-x: hidden;
+            white-space: nowrap;
             min-height: 1.5rem;
+
+            &.pd-dropdown-text-wrap {
+                white-space: normal;
+            }
         }
 
         .pd-dropdown-caret {

--- a/src/components/pd-dropdown/pd-dropdown.tsx
+++ b/src/components/pd-dropdown/pd-dropdown.tsx
@@ -1,6 +1,6 @@
 import { createPopper, Instance } from '@popperjs/core';
 import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop, State } from '@stencil/core';
-import { DropdownItem } from '../../interface';
+import { DropdownItem, TextWrap } from '../../interface';
 import { closestParentElement } from '../../utils/helpers';
 @Component({
     tag: 'pd-dropdown',
@@ -72,6 +72,11 @@ export class Dropdown {
      * Default vertical adjustment for inline forms
      */
     @Prop() verticalAdjust: boolean = false;
+
+    /**
+     * Selected item text wrap on words
+     */
+    @Prop() textWrap: TextWrap = 'no-wrap';
 
     /**
      * Set a preselected entry by index
@@ -228,7 +233,10 @@ export class Dropdown {
                         disabled={this.disabled || this.readonly}
                         data-test="pd-dropdown-button"
                     >
-                        <span class="pd-dropdown-text" data-test="pd-dropdown-text">
+                        <span
+                            class={{ 'pd-dropdown-text': true, 'pd-dropdown-text-wrap': this.textWrap === 'wrap' }}
+                            data-test="pd-dropdown-text"
+                        >
                             {this.selectedItem?.label || this.placeholder}
                         </span>
                         <pd-icon

--- a/src/components/pd-dropdown/readme.md
+++ b/src/components/pd-dropdown/readme.md
@@ -51,19 +51,20 @@ More info on [prop modifier](https://vuejs.org/v2/api/#v-bind)
 
 ## Properties
 
-| Property         | Attribute         | Description                                                        | Type             | Default                                                             |
-| ---------------- | ----------------- | ------------------------------------------------------------------ | ---------------- | ------------------------------------------------------------------- |
-| `disabled`       | `disabled`        | If `true`, the user cannot interact with the input.                | `boolean`        | `false`                                                             |
-| `emptyItem`      | `empty-item`      | Enable selection of an empty item                                  | `boolean`        | `false`                                                             |
-| `emptyItemData`  | --                | Data used for the empty item                                       | `DropdownItem`   | `{         id: '0',         label: '-',         value: null,     }` |
-| `error`          | `error`           | Shows error state                                                  | `boolean`        | `false`                                                             |
-| `itemCount`      | `item-count`      | Items visible in dropdown                                          | `number`         | `5`                                                                 |
-| `items`          | --                | Items to display and select in dropdown                            | `DropdownItem[]` | `[]`                                                                |
-| `label`          | `label`           | Dropdown box label                                                 | `string`         | `undefined`                                                         |
-| `placeholder`    | `placeholder`     | Placeholder when no item is selected                               | `string`         | `''`                                                                |
-| `readonly`       | `readonly`        | If `true`, the user cannot modify the value.                       | `boolean`        | `false`                                                             |
-| `required`       | `required`        | If `true`, the user must fill in a value before submitting a form. | `boolean`        | `false`                                                             |
-| `verticalAdjust` | `vertical-adjust` | Default vertical adjustment for inline forms                       | `boolean`        | `false`                                                             |
+| Property         | Attribute         | Description                                                        | Type                  | Default                                                             |
+| ---------------- | ----------------- | ------------------------------------------------------------------ | --------------------- | ------------------------------------------------------------------- |
+| `disabled`       | `disabled`        | If `true`, the user cannot interact with the input.                | `boolean`             | `false`                                                             |
+| `emptyItem`      | `empty-item`      | Enable selection of an empty item                                  | `boolean`             | `false`                                                             |
+| `emptyItemData`  | --                | Data used for the empty item                                       | `DropdownItem`        | `{         id: '0',         label: '-',         value: null,     }` |
+| `error`          | `error`           | Shows error state                                                  | `boolean`             | `false`                                                             |
+| `itemCount`      | `item-count`      | Items visible in dropdown                                          | `number`              | `5`                                                                 |
+| `items`          | --                | Items to display and select in dropdown                            | `DropdownItem[]`      | `[]`                                                                |
+| `label`          | `label`           | Dropdown box label                                                 | `string`              | `undefined`                                                         |
+| `placeholder`    | `placeholder`     | Placeholder when no item is selected                               | `string`              | `''`                                                                |
+| `readonly`       | `readonly`        | If `true`, the user cannot modify the value.                       | `boolean`             | `false`                                                             |
+| `required`       | `required`        | If `true`, the user must fill in a value before submitting a form. | `boolean`             | `false`                                                             |
+| `textWrap`       | `text-wrap`       | Selected item text wrap on words                                   | `"no-wrap" \| "wrap"` | `'no-wrap'`                                                         |
+| `verticalAdjust` | `vertical-adjust` | Default vertical adjustment for inline forms                       | `boolean`             | `false`                                                             |
 
 
 ## Events

--- a/src/interface.d.ts
+++ b/src/interface.d.ts
@@ -59,6 +59,8 @@ export interface DropdownItem {
     selected?: boolean;
 }
 
+export type TextWrap = 'wrap' | 'no-wrap';
+
 export interface ComboboxItem extends DropdownItem { }
 
 export interface SelectedEvent {


### PR DESCRIPTION
Dropdown doesn't wrap text by default to better align with standard input. TextWrap property added.