### PR TITLE
#284 added a counter chip for selected items

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -170,6 +170,10 @@ export namespace Components {
          */
         "disableFilter": boolean;
         /**
+          * If `true`, the button to deselect all selected items will not be shown.
+         */
+        "disableMultiselectCounter": boolean;
+        /**
           * If `true`, the user cannot interact with the input.
          */
         "disabled": boolean;
@@ -2017,6 +2021,10 @@ declare namespace LocalJSX {
           * If true, the combobox will not search/filter in the items (for example when the combobox is used to make backend searches)
          */
         "disableFilter"?: boolean;
+        /**
+          * If `true`, the button to deselect all selected items will not be shown.
+         */
+        "disableMultiselectCounter"?: boolean;
         /**
           * If `true`, the user cannot interact with the input.
          */

--- a/src/components/pd-chip/readme.md
+++ b/src/components/pd-chip/readme.md
@@ -50,6 +50,10 @@
 
 ## Dependencies
 
+### Used by
+
+ - [pd-combobox](../pd-combobox)
+
 ### Depends on
 
 - [pd-icon](../pd-icon)
@@ -58,6 +62,7 @@
 ```mermaid
 graph TD;
   pd-chip --> pd-icon
+  pd-combobox --> pd-chip
   style pd-chip fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/pd-combobox/pd-combobox.scss
+++ b/src/components/pd-combobox/pd-combobox.scss
@@ -44,6 +44,8 @@
         padding-left: 3rem;
         border-radius: 0.25rem;
         border: 0.125rem solid setcolor(primary, enabled);
+        transition-property: padding-left;
+        transition-duration: 0.1s;
 
         &:focus-visible {
             background-color: $yellow-1;
@@ -52,6 +54,10 @@
             & .pd-combobox-icon {
                 fill: $blue-whale;
             }
+        }
+
+        &.pd-combobox-input-with-multiselect-counter {
+            padding-left: 8rem;
         }
     }
 
@@ -74,6 +80,10 @@
 
         &.right {
             right: 0.25rem;
+        }
+
+        &.pd-combobox-multiselect-counter {
+            left: 3.5rem;
         }
     }
 

--- a/src/components/pd-combobox/pd-combobox.stories.ts
+++ b/src/components/pd-combobox/pd-combobox.stories.ts
@@ -9,6 +9,7 @@ const defaultArgs = {
     viewonly: false,
     selectable: false,
     multiselect: false,
+    disableMultiselectCounter: false,
     error: false,
     required: false,
     highlight: false,
@@ -70,6 +71,7 @@ const basic = args => {
     c1.viewOnly = args.viewonly;
     c1.selectable = args.selectable;
     c1.multiselect = args.multiselect;
+    c1.disableMultiselectCounter = args.disableMultiselectCounter;
     c1.error = args.error;
     c1.required = args.required;
     c1.label = args.label;
@@ -104,6 +106,7 @@ const selectable = args => {
     c2.viewOnly = args.viewonly;
     c2.selectable = args.selectable;
     c2.multiselect = args.multiselect;
+    c2.disableMultiselectCounter = args.disableMultiselectCounter;
     c2.error = args.error;
     c2.required = args.required;
     c2.label = args.label + ' (selectable)';
@@ -138,6 +141,7 @@ const multiSelect = args => {
     c3.viewOnly = args.viewonly;
     c3.selectable = args.selectable;
     c3.multiselect = args.multiselect;
+    c3.disableMultiselectCounter = args.disableMultiselectCounter;
     c3.error = args.error;
     c3.required = args.required;
     c3.label = args.label + ' (mulitselect)';

--- a/src/components/pd-combobox/pd-combobox.tsx
+++ b/src/components/pd-combobox/pd-combobox.tsx
@@ -509,6 +509,8 @@ export class Combobox implements ComponentInterface, ComponentWillLoad, Componen
     }
 
     public render() {
+        const showMultiSelectCounter =
+            this.multiselect && !this.disableMultiselectCounter && !this.error && this.state.items.filter(item => item.selected).length > 0;
         return (
             <Host role="combobox">
                 <label
@@ -529,11 +531,7 @@ export class Combobox implements ComponentInterface, ComponentWillLoad, Componen
                                 class={{
                                     'pd-combobox-input': true,
                                     'pd-combobox-input-with-icon': this.selectable && S.selectedHasIcon(this.state),
-                                    'pd-combobox-input-with-multiselect-counter':
-                                        this.multiselect &&
-                                        !this.disableMultiselectCounter &&
-                                        !this.error &&
-                                        this.state.items.filter(item => item.selected).length > 0,
+                                    'pd-combobox-input-with-multiselect-counter': showMultiSelectCounter,
                                 }}
                                 data-test="pd-combobox-input"
                                 ref={input => (this.nativeInput = input)}
@@ -557,15 +555,15 @@ export class Combobox implements ComponentInterface, ComponentWillLoad, Componen
                                 </button>
                             ) : null}
 
-                            {this.multiselect &&
-                            !this.disableMultiselectCounter &&
-                            !this.error &&
-                            this.state.items.filter(item => item.selected).length > 0 ? (
+                            {showMultiSelectCounter ? (
                                 <div class="pd-combobox-icon pd-combobox-multiselect-counter">
                                     <pd-chip
                                         disabled={this.disabled}
                                         type={this.readonly || this.disabled ? 'text' : 'toggle'}
-                                        onClick={() => this.deselectAllItems()}
+                                        onClick={() => {
+                                            if (this.disabled || this.readonly) return;
+                                            return this.deselectAllItems();
+                                        }}
                                     >
                                         {this.state.items.filter(item => item.selected).length}
                                     </pd-chip>

--- a/src/components/pd-combobox/pd-combobox.tsx
+++ b/src/components/pd-combobox/pd-combobox.tsx
@@ -86,6 +86,11 @@ export class Combobox implements ComponentInterface, ComponentWillLoad, Componen
     @Prop() multiselect = false;
 
     /**
+     * If `true`, the button to deselect all selected items will not be shown.
+     */
+    @Prop() disableMultiselectCounter = false;
+
+    /**
      * Instructional text that shows before the input has a value.
      */
     @Prop() placeholder?: string;
@@ -425,6 +430,12 @@ export class Combobox implements ComponentInterface, ComponentWillLoad, Componen
         this.setFocus();
     }
 
+    private deselectAllItems() {
+        this.state.items = this.state.items.map(item => ({ ...item, selected: false }));
+        this.state.filteredItems = this.state.items;
+        this.pdCombobox.emit(null);
+    }
+
     private onInputClick = () => {
         if (this.state.open === true) {
             S.closeDropdown(this.state);
@@ -518,6 +529,11 @@ export class Combobox implements ComponentInterface, ComponentWillLoad, Componen
                                 class={{
                                     'pd-combobox-input': true,
                                     'pd-combobox-input-with-icon': this.selectable && S.selectedHasIcon(this.state),
+                                    'pd-combobox-input-with-multiselect-counter':
+                                        this.multiselect &&
+                                        !this.disableMultiselectCounter &&
+                                        !this.error &&
+                                        this.state.items.filter(item => item.selected).length > 0,
                                 }}
                                 data-test="pd-combobox-input"
                                 ref={input => (this.nativeInput = input)}
@@ -539,6 +555,21 @@ export class Combobox implements ComponentInterface, ComponentWillLoad, Componen
                                 <button class="pd-combobox-icon left" tabindex="-1" onClick={() => this.setFocus()}>
                                     <pd-icon class="pd-icon pd-combobox-icon-search" name="search" size={2.4}></pd-icon>
                                 </button>
+                            ) : null}
+
+                            {this.multiselect &&
+                            !this.disableMultiselectCounter &&
+                            !this.error &&
+                            this.state.items.filter(item => item.selected).length > 0 ? (
+                                <div class="pd-combobox-icon pd-combobox-multiselect-counter">
+                                    <pd-chip
+                                        disabled={this.disabled}
+                                        type={this.readonly || this.disabled ? 'text' : 'toggle'}
+                                        onClick={() => this.deselectAllItems()}
+                                    >
+                                        {this.state.items.filter(item => item.selected).length}
+                                    </pd-chip>
+                                </div>
                             ) : null}
 
                             {this.selectable && S.selectedHasIcon(this.state) ? (

--- a/src/components/pd-combobox/readme.md
+++ b/src/components/pd-combobox/readme.md
@@ -54,26 +54,27 @@ To add an icon to the label of the dropdownitem use the iconName (for the suppor
 
 ## Properties
 
-| Property         | Attribute         | Description                                                                                                                | Type             | Default                                                             |
-| ---------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------------------------------------------------------------------- |
-| `disableFilter`  | `disable-filter`  | If true, the combobox will not search/filter in the items (for example when the combobox is used to make backend searches) | `boolean`        | `false`                                                             |
-| `disabled`       | `disabled`        | If `true`, the user cannot interact with the input.                                                                        | `boolean`        | `false`                                                             |
-| `emptyItem`      | `empty-item`      | Enable selection of an empty item                                                                                          | `boolean`        | `false`                                                             |
-| `emptyItemData`  | --                | Data used for the empty item                                                                                               | `ComboboxItem`   | `{         id: '0',         label: '-',         value: null,     }` |
-| `error`          | `error`           | Shows error state                                                                                                          | `boolean`        | `false`                                                             |
-| `highlight`      | `highlight`       | Show matching parts in results as highlighted                                                                              | `boolean`        | `true`                                                              |
-| `itemCount`      | `item-count`      | Items visible in dropdown                                                                                                  | `number`         | `5`                                                                 |
-| `items`          | --                | Values shown as combobox items                                                                                             | `ComboboxItem[]` | `[]`                                                                |
-| `label`          | `label`           | combobox box label                                                                                                         | `string`         | `undefined`                                                         |
-| `multiselect`    | `multiselect`     | If `true`, the combobox can select multiple items.                                                                         | `boolean`        | `false`                                                             |
-| `placeholder`    | `placeholder`     | Instructional text that shows before the input has a value.                                                                | `string`         | `undefined`                                                         |
-| `readonly`       | `readonly`        | If `true`, the user cannot modify the value.                                                                               | `boolean`        | `false`                                                             |
-| `required`       | `required`        | If `true`, the user must fill in a value before submitting a form.                                                         | `boolean`        | `false`                                                             |
-| `selectable`     | `selectable`      | If `true`, the combobox get a selected state like a dropdown.                                                              | `boolean`        | `false`                                                             |
-| `size`           | `size`            | Input tag size (check pd-input 'size' for more info)                                                                       | `number`         | `1`                                                                 |
-| `value`          | `value`           | The value of the input.                                                                                                    | `string`         | `''`                                                                |
-| `verticalAdjust` | `vertical-adjust` | Default vertical adjustment for inline forms                                                                               | `boolean`        | `false`                                                             |
-| `viewOnly`       | `view-only`       | If `true`, the combobox is replaced with a simple text                                                                     | `boolean`        | `false`                                                             |
+| Property                    | Attribute                     | Description                                                                                                                | Type             | Default                                                             |
+| --------------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------------------------------------------------------------------- |
+| `disableFilter`             | `disable-filter`              | If true, the combobox will not search/filter in the items (for example when the combobox is used to make backend searches) | `boolean`        | `false`                                                             |
+| `disableMultiselectCounter` | `disable-multiselect-counter` | If `true`, the button to deselect all selected items will not be shown.                                                    | `boolean`        | `false`                                                             |
+| `disabled`                  | `disabled`                    | If `true`, the user cannot interact with the input.                                                                        | `boolean`        | `false`                                                             |
+| `emptyItem`                 | `empty-item`                  | Enable selection of an empty item                                                                                          | `boolean`        | `false`                                                             |
+| `emptyItemData`             | --                            | Data used for the empty item                                                                                               | `ComboboxItem`   | `{         id: '0',         label: '-',         value: null,     }` |
+| `error`                     | `error`                       | Shows error state                                                                                                          | `boolean`        | `false`                                                             |
+| `highlight`                 | `highlight`                   | Show matching parts in results as highlighted                                                                              | `boolean`        | `true`                                                              |
+| `itemCount`                 | `item-count`                  | Items visible in dropdown                                                                                                  | `number`         | `5`                                                                 |
+| `items`                     | --                            | Values shown as combobox items                                                                                             | `ComboboxItem[]` | `[]`                                                                |
+| `label`                     | `label`                       | combobox box label                                                                                                         | `string`         | `undefined`                                                         |
+| `multiselect`               | `multiselect`                 | If `true`, the combobox can select multiple items.                                                                         | `boolean`        | `false`                                                             |
+| `placeholder`               | `placeholder`                 | Instructional text that shows before the input has a value.                                                                | `string`         | `undefined`                                                         |
+| `readonly`                  | `readonly`                    | If `true`, the user cannot modify the value.                                                                               | `boolean`        | `false`                                                             |
+| `required`                  | `required`                    | If `true`, the user must fill in a value before submitting a form.                                                         | `boolean`        | `false`                                                             |
+| `selectable`                | `selectable`                  | If `true`, the combobox get a selected state like a dropdown.                                                              | `boolean`        | `false`                                                             |
+| `size`                      | `size`                        | Input tag size (check pd-input 'size' for more info)                                                                       | `number`         | `1`                                                                 |
+| `value`                     | `value`                       | The value of the input.                                                                                                    | `string`         | `''`                                                                |
+| `verticalAdjust`            | `vertical-adjust`             | Default vertical adjustment for inline forms                                                                               | `boolean`        | `false`                                                             |
+| `viewOnly`                  | `view-only`                   | If `true`, the combobox is replaced with a simple text                                                                     | `boolean`        | `false`                                                             |
 
 
 ## Events
@@ -143,13 +144,16 @@ Type: `Promise<void>`
 ### Depends on
 
 - [pd-icon](../pd-icon)
+- [pd-chip](../pd-chip)
 - [pd-dropdown-item](../pd-dropdown-item)
 
 ### Graph
 ```mermaid
 graph TD;
   pd-combobox --> pd-icon
+  pd-combobox --> pd-chip
   pd-combobox --> pd-dropdown-item
+  pd-chip --> pd-icon
   pd-dropdown-item --> pd-checkbox
   pd-dropdown-item --> pd-icon
   style pd-combobox fill:#f9f,stroke:#333,stroke-width:4px

--- a/src/index.html
+++ b/src/index.html
@@ -267,10 +267,10 @@
                 </details>
             </details>
 
-            <details>
+            <details open>
                 <summary>Forms</summary>
 
-                <details>
+                <details open>
                     <summary>Inputs</summary>
                     <div class="dropdown-grid">
                         <span></span>
@@ -588,13 +588,13 @@
                 </details>
             </details>
 
-            <details open>
+            <details>
                 <summary>Page Elements</summary>
                 <details>
                     <summary>Animations</summary>
                     <pd-animation name="under-construction"></pd-animation>
                 </details>
-                <details open>
+                <details>
                     <summary>Skeleton Loader</summary>
                     <pd-skeleton></pd-skeleton>
                 </details>


### PR DESCRIPTION
#284

is there a better way of doing this twice?

this.multiselect &&
!this.disableMultiselectCounter && 
!this.error &&
this.state.items.filter(item => item.selected).length > 0,
